### PR TITLE
Build gnubg on CI during pull requests

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -1,6 +1,8 @@
 name: CI Builds
 
-on: push
+on:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   build-without-gtk:

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Dependencies
       run: |
-        sudo apt-get -y install gcc musl-dev
-        sudo apt-get -y install cvs libtool automake autoconf make bison flex file texinfo patch
+        # All dependencies here are already preinstalled, so this is just for demonstration purposes.
+        sudo apt-get -y install gcc libtool automake autoconf make bison flex file texinfo patch
     - name: configure
       run: |
         chmod +x autogen.sh && ./autogen.sh

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -1,22 +1,26 @@
-name: C/C++ CI
+name: CI Builds
 
 on: push
 
 jobs:
-  build:
-
+  build-without-gtk:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./gnubg
 
     steps:
     - uses: actions/checkout@v3
     - name: Install Dependencies
       run: |
-        apk add --no-cache gcc musl-dev
+        sudo apt-get -y install gcc musl-dev
+        sudo apt-get -y install cvs libtool automake autoconf make bison flex file texinfo patch
     - name: configure
-      run: ./configure
+      run: |
+        chmod +x autogen.sh && ./autogen.sh
+        ./configure
     - name: make
       run: make
     - name: make check
       run: make check
-    - name: make distcheck
-      run: make distcheck
+  

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -1,0 +1,22 @@
+name: C/C++ CI
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Dependencies
+      run: |
+        apk add --no-cache gcc musl-dev
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck


### PR DESCRIPTION
Whenever a new pull request is created or new commits are pushed, gnubg is built (without GTK) to check whether the project still compiles.